### PR TITLE
feature/CURV-11136 - User receives a "500 Unknown error" when trying to sign an EIP 712 tx

### DIFF
--- a/eip712_structs/types.py
+++ b/eip712_structs/types.py
@@ -132,7 +132,7 @@ class Bytes(EIP712Type):
         if self.length == 0:
             return keccak(value)
         else:
-            if len(value) > self.length:
+            if len(value) != self.length:
                 raise ValueError(f'{self.type_name} was given bytes with length {len(value)}')
             padding = bytes(32 - len(value))
             return value + padding

--- a/tests/test_encode_data.py
+++ b/tests/test_encode_data.py
@@ -70,8 +70,8 @@ def test_encode_bytes():
     class TestStruct(EIP712Struct):
         b = Bytes(4)
 
-    s1 = TestStruct(b='0xffee')
-    s2 = TestStruct(b=b'\xff\xee')
+    s1 = TestStruct(b='0xffeeddcc')
+    s2 = TestStruct(b=b'\xff\xee\xdd\xcc')
     assert s1.encode_value() == s2.encode_value()
     with pytest.raises(ValueError):
         TestStruct(b='0xffffffffff')  # too long

--- a/tests/test_message_json.py
+++ b/tests/test_message_json.py
@@ -190,6 +190,32 @@ def test_extra_field_from_message_error(message):
         EIP712Struct.from_message(message)
 
 
+@pytest.mark.parametrize('message', [
+    {
+        'primaryType': 'Foo',
+        'types': {
+            'EIP712Domain': [{
+                'name': 'name',
+                'type': 'string',
+            }],
+            'Foo': [{
+                'name': 's',
+                'type': 'bytes4',
+            }]
+        },
+        'domain': {
+            'name': 'domain',
+        },
+        'message': {
+            's': '0xff',  # shorter than 4 bytes
+        }
+    },
+])
+def test_bytes_too_short_from_message_error(message):
+    with pytest.raises(ValueError):
+        EIP712Struct.from_message(message)
+
+
 def test_bytes_json_encoder():
     class Foo(EIP712Struct):
         b = Bytes(32)


### PR DESCRIPTION
removed auto padding for bytes values which are too short

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/curv85/py-eip712-structs/2)
<!-- Reviewable:end -->
